### PR TITLE
Add parallel ODE parameter estimation with PSO

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "1.0.0-DEV"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+DiffEqGPU = "071ae1c0-96b5-11e9-1965-c90190d839ea"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"

--- a/src/PSOGPU.jl
+++ b/src/PSOGPU.jl
@@ -2,6 +2,8 @@ module PSOGPU
 
 using SciMLBase, StaticArrays, Setfield, CUDA
 
+import DiffEqGPU: GPUTsit5, vectorized_asolve, make_prob_compatible
+
 ## Use lb and ub either as StaticArray or pass them separately as CuArrays
 ## Passing as CuArrays makes more sense, or maybe SArray? The based on no. of dimension
 struct PSOParticle{T1, T2 <: eltype(T1)}
@@ -45,6 +47,7 @@ include("./pso_gpu.jl")
 include("./pso_async_gpu.jl")
 include("./utils.jl")
 include("./pso_sync_gpu.jl")
+include("./ode_pso.jl")
 
 function SciMLBase.__solve(prob::OptimizationProblem,
     opt::ParallelPSOKernel,

--- a/src/ode_pso.jl
+++ b/src/ode_pso.jl
@@ -1,0 +1,89 @@
+function _update_particle_states!(lb, ub, gpu_particles, gbest, w; c1 = 1.4962f0,
+    c2 = 1.4962f0)
+    i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    i > length(gpu_particles) && return
+
+    @inbounds particle = gpu_particles[i]
+
+    updated_velocity = w .* particle.velocity .+
+                       c1 .* rand(typeof(particle.velocity)) .* (particle.best_position -
+                        particle.position) .+
+                       c2 .* rand(typeof(particle.velocity)) .*
+                       (gbest.position - particle.position)
+
+    @set! particle.velocity = updated_velocity
+
+    @set! particle.position = particle.position + particle.velocity
+
+    update_pos = max(particle.position, lb)
+    update_pos = min(update_pos, ub)
+
+    @set! particle.position = update_pos
+
+    @inbounds gpu_particles[i] = particle
+
+    return nothing
+end
+
+function _update_particle_costs!(losses, gpu_particles)
+    i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    i > length(losses) && return
+
+    @inbounds particle = gpu_particles[i]
+
+    @set! particle.cost = convert(typeof(particle.cost), losses[i])
+
+    if particle.cost < particle.best_cost
+        @set! particle.best_position = particle.position
+        @set! particle.best_cost = particle.cost
+    end
+
+    @inbounds gpu_particles[i] = particle
+
+    return nothing
+end
+
+function remake_prob_gpu(prob, gpu_particle)
+    return make_prob_compatible(remake(prob, p = gpu_particle.position))
+end
+
+function parameter_estim_ode!(prob::ODEProblem,
+    gpu_particles,
+    gbest,
+    data,
+    lb,
+    ub;
+    ode_alg = GPUTsit5(),
+    w = 0.72980,
+    wdamp = 1.00,
+    maxiters = 100, kwargs...)
+    update_states! = @cuda launch=false _update_particle_states!(lb,
+        ub,
+        gpu_particles,
+        gbest,
+        w)
+
+    improb = make_prob_compatible(prob)
+
+    for i in 1:maxiters
+        update_states!(lb, ub, gpu_particles, gbest, w)
+
+        probs = remake_prob_gpu.(Ref(improb), gpu_particles)
+
+        ts, us = vectorized_asolve(probs,
+            prob,
+            ode_alg; kwargs...)
+
+        losses = sum((map(x -> sum(x .^ 2), data .- us)), dims = 1)
+
+        @cuda _update_particle_costs!(losses, gpu_particles)
+
+        # @show typeof(gpu_particles)
+
+        best_particle = minimum(gpu_particles)
+        gbest = PSOGPU.PSOGBest(best_particle.best_position, best_particle.best_cost)
+        # @show gbest
+        w = w * wdamp
+    end
+    return gbest
+end


### PR DESCRIPTION
A first draft of completely GPU parallel implementation of parameter estimation of ODEs using PSO

Example:

```julia
using StaticArrays, SciMLBase

function f(u, p, t)
    dx = p[1] * u[1] - u[1] * u[2]
    dy = -3 * u[2] + u[1] * u[2]
    return SVector{2}(dx,dy)
end

u0 = @SArray [1.0; 1.0]
tspan = (0.0, 10.0)
p = @SArray [1.5]
prob = ODEProblem(f, u0, tspan, p)

using OrdinaryDiffEq
sol = solve(prob, Tsit5())
t = collect(range(0f0, stop = 10.0, length = 200))
using RecursiveArrayTools # for VectorOfArray
randomized = VectorOfArray([(sol(t[i]) + 0.01randn(2)) for i in 1:length(t)])

data = convert(Array, randomized)

n_particles = 1000

maxiters = 1000

n = 1

lb = @SArray ones(n)

lb = -10*lb

ub = @SArray ones(n)

ub = 10*ub


function loss(u,p)
    odeprob, t = p
    prob = remake(odeprob; p = u)
    pred = Array(solve(prob, Tsit5(), saveat = t))
    sum(abs2, data .- pred)
end

optprob = OptimizationProblem(loss, [1.0], (prob,t);lb, ub)

using PSOGPU
using CUDA


gbest, particles = PSOGPU.init_particles(optprob, n_particles)

gpu_data = cu([SVector{length(prob.u0), eltype(prob.u0)}(@view data[:,i]) for i in 1:length(t)])


gpu_particles = cu(particles)


@time gsol = PSOGPU.parameter_estim_ode!(prob,
    gpu_particles,
    gbest,
    gpu_data,
    lb,
    ub; saveat = t, dt = 0.1)

```
IMO, the timings are pretty great:

```julia
julia> @time gsol = PSOGPU.parameter_estim_ode!(prob,
           gpu_particles,
           gbest,
           gpu_data,
           lb,
           ub; saveat = t, dt = 0.1)
  0.122097 seconds (26.01 k allocations: 1.359 MiB)
PSOGPU.PSOGBest{SVector{1, Float64}, Float64}([1.4996615334532823], 0.05371133040880362)
```