### PR TITLE
Documentation improvements: fix badge URL, docstrings, and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/SciML/ParallelParticleSwarms.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/SciML/ParallelParticleSwarms.jl/actions/workflows/CI.yml)
 [![Build status](https://badge.buildkite.com/caf5d6f9d5129b5796049b085df39fd8fab055826b513d361e.svg)](https://buildkite.com/julialang/parallelparticleswarms-dot-jl)
-[![codecov](https://codecov.io/gh/utkarsh530/ParallelParticleSwarms.jl/graph/badge.svg?token=H5U5UAIRXX)](https://codecov.io/gh/utkarsh530/ParallelParticleSwarms.jl)
+[![codecov](https://codecov.io/gh/SciML/ParallelParticleSwarms.jl/graph/badge.svg?token=H5U5UAIRXX)](https://codecov.io/gh/SciML/ParallelParticleSwarms.jl)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor%27s%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)
 

--- a/examples/neural_network/nn.jl
+++ b/examples/neural_network/nn.jl
@@ -54,5 +54,5 @@ prob = OptimizationProblem((u, data) -> lenetloss(data, u), p, xtrain; lb = lb, 
 n_particles = 1000
 
 sol = solve(prob,
-    ParallelPSOKernel(n_particles; threaded = true),
+    ParallelPSOKernel(n_particles),
     maxiters = 1000)

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -11,18 +11,22 @@ end
 
 """
 ```julia
-ParallelPSOKernel(num_particles = 100)
+ParallelPSOKernel(num_particles; global_update = true, backend = CPU())
 ```
 
 Particle Swarm Optimization on a GPU. Creates and launches a kernel which updates the particle states in parallel
 on a GPU. Static Arrays for parameters in the `OptimizationProblem` are required for successful GPU compilation.
 
-## Positional arguments:
+## Arguments
 
-- num_particles: Number of particles in the simulation
-- global_update: defaults to `true`. Setting it to false allows particles to evolve completely on their own,
+- `num_particles`: Number of particles in the simulation (positional argument)
+
+## Keyword Arguments
+
+- `global_update`: defaults to `true`. Setting it to `false` allows particles to evolve completely on their own,
   i.e. no information is sent about the global best position.
-- backend: defaults to `CPU()`. The KernelAbstractions backend for performing the computation.
+- `backend`: defaults to `CPU()`. The KernelAbstractions backend for performing the computation
+  (e.g., `CUDA.CUDABackend()` for NVIDIA GPUs).
 
 ## Limitations
 
@@ -42,16 +46,20 @@ end
 
 """
 ```julia
-ParallelSyncPSOKernel(num_particles = 100)
+ParallelSyncPSOKernel(num_particles; backend = CPU())
 ```
 
 Particle Swarm Optimization on a GPU. Creates and launches a kernel which updates the particle states in parallel
 on a GPU. However, it requires a synchronization after each generation to calculate the global best position of the particles.
 
-## Positional arguments:
+## Arguments
 
-- num_particles: Number of particles in the simulation
-- backend: defaults to `CPU()`. The KernelAbstractions backend for performing the computation.
+- `num_particles`: Number of particles in the simulation (positional argument)
+
+## Keyword Arguments
+
+- `backend`: defaults to `CPU()`. The KernelAbstractions backend for performing the computation
+  (e.g., `CUDA.CUDABackend()` for NVIDIA GPUs).
 
 """
 struct ParallelSyncPSOKernel{Backend, T, G, H} <: PSOAlgorithm
@@ -64,15 +72,15 @@ end
 
 """
 ```julia
-ParallelPSOArray(num_particles = 100)
+ParallelPSOArray(num_particles)
 ```
+
 Particle Swarm Optimization on a CPU. It keeps the arrays used in particle data structure
 to be Julia's `Array`, which may be better for high-dimensional problems.
 
-## Positional arguments:
+## Arguments
 
-- num_particles: Number of particles in the simulation
-
+- `num_particles`: Number of particles in the simulation (positional argument)
 
 ## Limitations
 
@@ -90,13 +98,14 @@ end
 
 """
 ```julia
-SerialPSO(num_particles = 100)
+SerialPSO(num_particles)
 ```
+
 Serial Particle Swarm Optimization on a CPU.
 
-## Positional arguments:
+## Arguments
 
-- num_particles: Number of particles in the simulation
+- `num_particles`: Number of particles in the simulation (positional argument)
 
 """
 struct SerialPSO{T, G, H} <: PSOAlgorithm


### PR DESCRIPTION
## Summary

- Fix codecov badge URL to point to SciML organization instead of utkarsh530
- Fix docstring headers in `algorithms.jl`: change "Positional arguments" to properly separate "Arguments" and "Keyword Arguments" sections  
- Update function signatures in docstrings to show keyword arguments correctly
- Add example of GPU backend usage (`CUDA.CUDABackend()`) in docstrings
- Fix deprecated `threaded = true` keyword in neural network example (this keyword doesn't exist in the current API)

## Test plan

- [x] Package loads successfully
- [x] Docstrings render correctly  
- [x] All existing tests pass

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)