### PR TITLE
Migrate CI to SciML centralized reusable workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,29 +13,13 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    runs-on: ${{ matrix.os }}
+    name: "Tests"
     strategy:
       fail-fast: false
       matrix:
         version:
-          - '1'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v3
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          files: lcov.info
+          - "1"
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      julia-version: "${{ matrix.version }}"
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -2,30 +2,19 @@ name: Downgrade
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
 jobs:
   test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,5 +1,4 @@
 name: format-check
-
 on:
   push:
     branches:
@@ -8,15 +7,8 @@ on:
       - 'release-'
     tags: '*'
   pull_request:
-
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Format Check"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,0 +1,9 @@
+name: Spell Check
+
+on: [pull_request]
+
+jobs:
+  typos-check:
+    name: "Spell Check"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,2 @@
+[files]
+extend-exclude = ["*/Manifest.toml", "Manifest.toml"]

--- a/benchmarks/CPU_vs_GPU/benchmark.jl
+++ b/benchmarks/CPU_vs_GPU/benchmark.jl
@@ -384,7 +384,7 @@ using Statistics
 #     label = "ParallelSyncPSOKernel: GPU",
 #     ylabel = "Time (s)",
 #     xlabel = "No. of Particles",
-#     title = "Bechmarking the 10D Rosenbrock Problem",
+#     title = "Benchmarking the 10D Rosenbrock Problem",
 #     legend = :topleft,
 #     xticks = xticks,
 #     yticks = yticks,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ global CI_GROUP = get(ENV, "GROUP", "CPU")
 @safetestset "Reinitialization tests" include("./reinit.jl")
 @safetestset "JET static analysis" include("./jet.jl")
 
-#TODO: Curent throws warning for redefinition with the use of @testset multiple times. Migrate to TestItemRunners.jl
+#TODO: Current throws warning for redefinition with the use of @testset multiple times. Migrate to TestItemRunners.jl
 @testset for BACKEND in unique(("CPU", CI_GROUP))
     global GROUP = BACKEND
     @testset "$(BACKEND) optimizers tests" include("./gpu.jl")


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Normalizes CI to the SciML centralized reusable workflows (`SciML/.github`, all callers pinned `@v1`).

## Workflows converted
- **CI.yml** -> `tests.yml@v1` caller. Preserves the original matrix (Julia version `"1"`, ubuntu, x64) and coverage collection (codecov via `secrets: inherit`).
- **Downgrade.yml** -> `downgrade.yml@v1` caller. Preserves `julia-version: 1.10`, `skip: Pkg,TOML`, `alldeps`/`allow-reresolve: false` semantics. **Also fixes a latent bug**: the original `on:` triggered only on branch `master`, but the default branch is `main`, so the Downgrade job never actually ran. Changed to `main` so it now triggers.
- **FormatCheck.yml** -> `runic.yml@v1` caller. The repo already ran Runic (`fredrikekre/runic-action`) and is already Runic-formatted, so **no reformatting was applied** (`Runic --check` passes clean locally).

## Workflows added
- **SpellCheck.yml** -> `spellcheck.yml@v1` caller (new; SciML standard).

## Left unchanged
- **GPU.yml** (self-hosted CUDA tests with a custom `Pkg.add(CUDA)` pin step and Manifest removal) — not part of the centralized CPU standard set and not faithfully expressible through the centralized callers, so preserved as-is.
- **TagBot.yml** — unchanged.

## Typos / SpellCheck
`crate-ci/typos` (v1.47.0) locally reported:
- `Missings` (14x, all in `benchmarks/*/Manifest.toml`) — false positive (real Julia package name). Handled by a minimal `_typos.toml` excluding `Manifest.toml`.
- `Curent` -> `Current` (comment in `test/runtests.jl`) — real typo, fixed.
- `Bechmarking` -> `Benchmarking` (commented-out plot title in `benchmarks/CPU_vs_GPU/benchmark.jl`) — real typo, fixed.

After these changes `typos` exits clean locally.

## Dependabot / CompatHelper
- No `CompatHelper.yml` existed; nothing to remove.
- `dependabot.yml` already conforms to the standard (`github-actions` weekly at `/`; `julia` daily at `/` and `/test` with `groups.all-julia-packages.patterns: ["*"]`, no `crate-ci/typos` ignore block). The only dirs with a `Project.toml` are `/` and `/test`, both already listed. **No changes needed.**

## Note on branch protection
Check names change with this migration (e.g. the test job now appears under the reusable workflow's job names). Branch-protection **required-status-checks must be updated** accordingly, or merges may block on stale check names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)