### PR TITLE
Downgrade: raise StaticArrays compat floor to 1.9.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -40,7 +40,7 @@ SafeTestsets = "0.1"
 SciMLBase = "2.79, 3.0"
 Setfield = "1.1"
 SimpleNonlinearSolve = "2.12"
-StaticArrays = "1.9"
+StaticArrays = "1.9.8"
 Test = "1"
 julia = "1.10"
 


### PR DESCRIPTION
## Downgrade fix: raise StaticArrays compat floor to 1.9.8

### The conflict
The `Downgrade` workflow fails on the LTS (Julia 1.10) during precompilation:

```
ERROR: LoadError: UndefVarError: `require_one_based_indexing` not defined
in expression starting at .../StaticArrays/.../src/StaticArrays.jl:1
Failed to precompile StaticArrays [90137ffa-...]
  -> cascades to KernelAbstractions and the StaticArrays extensions
```

### Why the old floor was impossible
At the downgrade minimum the declared `StaticArrays = "1.9"` floor resolves to **StaticArrays v1.9.7**. That version's `src/StaticArrays.jl` (line 29) does:

```julia
using StaticArraysCore: ..., size_to_tuple, require_one_based_indexing
```

but StaticArrays 1.9.7 pins `StaticArraysCore = "~1.4.0"`, and StaticArraysCore 1.4.x does **not** export `require_one_based_indexing` (it only calls `Base.require_one_based_indexing` internally). So v1.9.7 imports a symbol that does not exist in its own allowed StaticArraysCore range and cannot precompile. The old floor was self-broken at the downgrade minimum.

StaticArrays **v1.9.8** removed that broken import from the StaticArraysCore `using` list, so it is the smallest 1.9.x that precompiles.

### The fix
Raise the floor to `StaticArrays = "1.9.8"`.

### Resolve/precompile verification (local, Julia 1.10.11 = CI lts)
Installed StaticArrays at each version and precompiled:

```
StaticArrays 1.9.7 -> UndefVarError: require_one_based_indexing not defined   (reproduces CI)
StaticArrays 1.9.8 -> PRECOMPILE+LOAD SUCCESS
```

### Note on the latest-versions ("CI") jobs
The downgrade-relevant config (Core, julia lts) passes on `master` at latest versions; the only `master` CI reds are `QA (julia 1)` (a runner `.gitconfig` lock glitch + codecov auth warning, JET analysis itself passed) and `Core (julia pre)` (a JET `Unsatisfiable` on the nightly channel). Both are unrelated to this StaticArrays downgrade floor and are not addressed here.

---
This PR is a draft. **Ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
