### PR TITLE
Canonicalize QA group to @safetestset

### DIFF
--- a/test/jet_tests.jl
+++ b/test/jet_tests.jl
@@ -1,0 +1,32 @@
+using JET
+using ParallelParticleSwarms
+using StaticArrays
+using Test
+
+@testset "Utility functions type stability" begin
+    @test_opt target_modules = (ParallelParticleSwarms,) ParallelParticleSwarms.θ_default(
+        0.5f0
+    )
+    @test_opt target_modules = (ParallelParticleSwarms,) ParallelParticleSwarms.γ_default(
+        0.5f0
+    )
+
+    @test_opt target_modules = (ParallelParticleSwarms,) ParallelParticleSwarms.uniform(
+        2, Float32[-5.0, -5.0], Float32[5.0, 5.0]
+    )
+end
+
+@testset "Particle struct construction" begin
+    T = SVector{2, Float32}
+    position = @SVector zeros(Float32, 2)
+    velocity = @SVector zeros(Float32, 2)
+    cost = 0.0f0
+
+    @test_opt target_modules = (ParallelParticleSwarms,) ParallelParticleSwarms.SPSOParticle(
+        position, velocity, cost, position, cost
+    )
+
+    @test_opt target_modules = (ParallelParticleSwarms,) ParallelParticleSwarms.SPSOGBest(
+        position, cost
+    )
+end

--- a/test/qa.jl
+++ b/test/qa.jl
@@ -1,34 +1,5 @@
-using JET
-using ParallelParticleSwarms
-using StaticArrays
-using Test
+using SafeTestsets
 
-@testset "JET static analysis" begin
-    @testset "Utility functions type stability" begin
-        @test_opt target_modules = (ParallelParticleSwarms,) ParallelParticleSwarms.θ_default(
-            0.5f0
-        )
-        @test_opt target_modules = (ParallelParticleSwarms,) ParallelParticleSwarms.γ_default(
-            0.5f0
-        )
-
-        @test_opt target_modules = (ParallelParticleSwarms,) ParallelParticleSwarms.uniform(
-            2, Float32[-5.0, -5.0], Float32[5.0, 5.0]
-        )
-    end
-
-    @testset "Particle struct construction" begin
-        T = SVector{2, Float32}
-        position = @SVector zeros(Float32, 2)
-        velocity = @SVector zeros(Float32, 2)
-        cost = 0.0f0
-
-        @test_opt target_modules = (ParallelParticleSwarms,) ParallelParticleSwarms.SPSOParticle(
-            position, velocity, cost, position, cost
-        )
-
-        @test_opt target_modules = (ParallelParticleSwarms,) ParallelParticleSwarms.SPSOGBest(
-            position, cost
-        )
-    end
+@safetestset "JET static analysis" begin
+    include("jet_tests.jl")
 end

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 ParallelParticleSwarms = "ab63da0c-63b4-40fa-a3b7-d2cba5be6419"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
@@ -9,5 +10,6 @@ ParallelParticleSwarms = {path = "../.."}
 
 [compat]
 JET = "0.9, 0.10, 0.11"
+SafeTestsets = "0.1"
 StaticArrays = "1.9"
 julia = "1.10"


### PR DESCRIPTION
## What

Canonicalizes the test suite toward the standard SciML/OrdinaryDiffEq structure where each independent unit runs in its own module via `@safetestset` (isolation + world-age safety).

### Changes
- **QA group**: `@testset "JET static analysis"` → `@safetestset "JET static analysis" begin include("jet_tests.jl") end`. The body was extracted into the new `test/jet_tests.jl`. The `include()` form is required (not an inline `@safetestset` body) because the body uses the JET `@test_opt` macro and StaticArrays' `@SVector` macro, which must resolve *after* their `using` lines run — `include` evaluates statements sequentially, whereas an inline `@safetestset` body macroexpands the whole block before the in-body `using`s take effect.
- `SafeTestsets` added to `test/qa/Project.toml` (the QA group activates its own environment).

### Already canonical / intentionally unchanged
- `regression.jl` and `reinit.jl` are **already** wrapped in `@safetestset` in `runtests.jl`.
- The backend-parameterized units (`gpu.jl`, `constraints.jl`, `lbfgs.jl`) run inside the `@testset for BACKEND in unique(("CPU", CI_GROUP))` dispatch loop. They are **left unchanged** because:
  1. their testset name is a *dynamic interpolated* string (`"$(BACKEND) optimizers tests"`), and `@safetestset` only accepts a literal `String` (it throws `ArgumentError` otherwise); and
  2. they depend on the loop-set `GROUP`/`backend` globals (via `utils.jl`), which a fresh `@safetestset` module cannot see.
  Converting them would require restructuring the GROUP/backend dispatch loop, which is out of scope for this behavior-preserving change.

### Verification
Ran the QA group locally on Julia 1.11:
```
Test Summary:       | Pass  Total   Time
JET static analysis |    5      5  27.7s
```
Exit code 0. No assertions or test logic changed.

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)