### PR TITLE
Downgrade: raise DiffEqGPU compat floor to 3.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 Adapt = "4.3"
-DiffEqGPU = "3.9"
+DiffEqGPU = "3.10"
 Enzyme = "0.13"
 ForwardDiff = "0.10, 1.3"
 JET = "0.9, 0.10, 0.11"


### PR DESCRIPTION
## Summary

Raises the `DiffEqGPU` compat **lower bound** from `3.9` to `3.10` to fix the failing `Downgrade / Downgrade Tests` job on `main`.

## Root cause

The downgrade-compat resolution pins `DiffEqGPU` to its floor, `v3.9.0`. That version's `src/ensemblegpukernel/integrators/integrator_utils.jl:373` references `DiffEqBase.determine_event_occurrence`, a symbol that has since been removed from DiffEqBase. With a current DiffEqBase (`v6.218.0`, which `v3.9.0`'s loose `DiffEqBase = "6.122"` compat happily allows) the symbol is gone, so DiffEqGPU — and therefore ParallelParticleSwarms — fails to precompile:

```
ERROR: LoadError: UndefVarError: `determine_event_occurrence` not defined
   @ DiffEqGPU .../ensemblegpukernel/integrators/integrator_utils.jl:373
```

`DiffEqGPU v3.10.0` removed that reference (commit removing `determine_event_occurrence` for the refactored DiffEqBase event API) and raised its own `DiffEqBase` floor to `6.205.1`, so it precompiles cleanly against current DiffEqBase. Raising the lower bound here is a safe lower-bound raise: it never restricts upgrades, only excludes the broken `3.9.x` floor.

## Local verification (Julia 1.10 / lts, the downgrade channel)

- Reproduced: `Pkg.add(DiffEqGPU@3.9.0)` → precompile fails with the exact `UndefVarError: determine_event_occurrence` at `integrator_utils.jl:373`.
- Fix: `Pkg.add(DiffEqGPU@3.10.0)` → precompiles and loads cleanly.
- Ran the action's own `downgrade.jl` over the patched `Project.toml`: resolver now picks `DiffEqGPU v3.10.0` with `DiffEqBase v6.218.0` and produces a valid manifest.

## Not addressed here (separate failures on `main`)

- **CUDA Tests (Julia 1):** self-hosted-runner infra error (`could not lock config file /home/.../.gitconfig: File exists`), not a code issue.
- **tests / Core (julia pre):** the `Rosenbrock N=4` PSO regression test diverges only on the Julia **1.13.0-rc1** prerelease (objective `3.70` vs `2.98e-13` on 1.12) — a Julia-version RNG-stream change in the stochastic optimizer, not a package bug. Left for separate handling (not a tolerance loosening).

Please ignore until reviewed by @ChrisRackauckas.
