### PR TITLE
Release prep: bump ParallelParticleSwarms to 1.1.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParallelParticleSwarms"
 uuid = "ab63da0c-63b4-40fa-a3b7-d2cba5be6419"
 authors = ["Utkarsh <rajpututkarsh530@gmail.com> and contributors"]
-version = "1.1.2"
+version = "1.1.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Patch version bump (1.1.2 -> 1.1.3) to release accumulated docstring/QA/test-scaffolding changes on main via JuliaRegistrator.