### PR TITLE
Expose configurable PSO coefficients across solver variants

### DIFF
--- a/src/hybrid.jl
+++ b/src/hybrid.jl
@@ -68,10 +68,14 @@ function SciMLBase.solve!(
         maxiters = 100,
         local_maxiters = 50,
         linesearch = StrongWolfeLineSearch(),
+        w = 0.7298f0,
+        wdamp = 1.0f0,
+        c1 = 1.4962f0,
+        c2 = 1.4962f0,
         kwargs...
     ) where {Backend, LocalOpt <: Union{LBFGS, BFGS}}
 
-    sol_pso = SciMLBase.solve!(cache.pso_cache; maxiters)
+    sol_pso = SciMLBase.solve!(cache.pso_cache; maxiters, w, wdamp, c1, c2)
     best_u = sol_pso.u
     best_obj = _unwrap_scalar(sol_pso.objective)
 

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -38,8 +38,7 @@ end
 @kernel function update_particle_states!(
         prob,
         gpu_particles::AbstractArray{SPSOParticle{T1, T2}}, gbest_ref, w,
-        opt::ParallelPSOKernel, lock::AbstractArray{UInt32}; c1 = 1.4962f0,
-        c2 = 1.4962f0
+        c1, c2, opt::ParallelPSOKernel, lock::AbstractArray{UInt32}
     ) where {T1, T2}
     i = @index(Global, Linear)
     tidx = @index(Local, Linear)
@@ -127,8 +126,7 @@ end
 @kernel function update_particle_states!(
         prob,
         gpu_particles::AbstractArray{SPSOParticle{T1, T2}}, block_particles, gbest, w,
-        opt::ParallelSyncPSOKernel; c1 = 1.4962f0,
-        c2 = 1.4962f0
+        c1, c2, opt::ParallelSyncPSOKernel
     ) where {T1, T2}
     i = @index(Global, Linear)
     tidx = @index(Local, Linear)
@@ -181,8 +179,7 @@ end
 # https://github.com/JuliaGPU/KernelAbstractions.jl/issues/330
 @kernel function update_particle_states!(
         prob, gpu_particles, gbest, w,
-        opt::ParallelSyncPSOKernel{Backend, T, G, H}; c1 = 1.4962f0,
-        c2 = 1.4962f0
+        c1, c2, opt::ParallelSyncPSOKernel{Backend, T, G, H}
     ) where {Backend <: CPU, T, G, H}
     i = @index(Global, Linear)
 
@@ -197,9 +194,7 @@ end
         prob,
         gpu_particles,
         gbest_ref,
-        w, wdamp, maxiters, opt;
-        c1 = 1.4962f0,
-        c2 = 1.4962f0
+        w, wdamp, c1, c2, maxiters, opt
     )
     i = @index(Global, Linear)
 

--- a/src/lowerlevel_solve.jl
+++ b/src/lowerlevel_solve.jl
@@ -5,6 +5,8 @@ function vectorized_solve!(
         maxiters = 100,
         w = 0.7298f0,
         wdamp = 1.0f0,
+        c1 = 1.4962f0,
+        c2 = 1.4962f0,
         debug = false
     )
     backend = get_backend(gpu_particles)
@@ -25,7 +27,7 @@ function vectorized_solve!(
             prob,
             gpu_particles, block_particles,
             gbest,
-            w, opt;
+            w, c1, c2, opt;
             ndrange = padded_ndrange
         )
         gbest = minimum(block_particles)
@@ -42,6 +44,8 @@ function vectorized_solve!(
         maxiters = 100,
         w = 0.7298f0,
         wdamp = 1.0f0,
+        c1 = 1.4962f0,
+        c2 = 1.4962f0,
         debug = false
     ) where {Backend <: CPU, T, G, H}
     backend = get_backend(gpu_particles)
@@ -53,7 +57,7 @@ function vectorized_solve!(
             prob,
             gpu_particles,
             gbest,
-            w, opt;
+            w, c1, c2, opt;
             ndrange = length(gpu_particles)
         )
         best_particle = minimum(gpu_particles)
@@ -71,6 +75,8 @@ function vectorized_solve!(
         maxiters = 100,
         w = 0.7298f0,
         wdamp = 1.0f0,
+        c1 = 1.4962f0,
+        c2 = 1.4962f0,
         debug = false
     )
 
@@ -85,7 +91,10 @@ function vectorized_solve!(
     fill!(lock, UInt32(0))
     for i in 1:maxiters
         ## Invoke GPU Kernel here
-        kernel(prob, gpu_particles, gbest, w, opt, lock; ndrange = padded_ndrange)
+        kernel(
+            prob, gpu_particles, gbest, w, c1, c2, opt, lock;
+            ndrange = padded_ndrange
+        )
         w = w * wdamp
     end
 
@@ -99,6 +108,8 @@ function vectorized_solve!(
         maxiters = 100,
         w = 0.7298f0,
         wdamp = 1.0f0,
+        c1 = 1.4962f0,
+        c2 = 1.4962f0,
         debug = false
     )
     backend = get_backend(gpu_particles)
@@ -111,6 +122,8 @@ function vectorized_solve!(
         gbest,
         w,
         wdamp,
+        c1,
+        c2,
         maxiters,
         opt;
         ndrange = padded_ndrange
@@ -209,11 +222,13 @@ function vectorized_solve!(
         maxiters = 100,
         w = 0.7298f0,
         wdamp = 1.0f0,
+        c1 = 1.4962f0,
+        c2 = 1.4962f0,
         debug = false
     )
     sol_ref = Ref(gbest)
     for i in 1:maxiters
-        update_particle_states_cpu!(prob, particles, sol_ref, w, i, opt)
+        update_particle_states_cpu!(prob, particles, sol_ref, w, i, opt; c1, c2)
         w = w * wdamp
     end
     return sol_ref[], particles

--- a/test/gpu.jl
+++ b/test/gpu.jl
@@ -27,7 +27,10 @@ include("./utils.jl")
 
     n_particles = 5000
 
-    sol = solve(prob, ParallelPSOKernel(n_particles; backend), maxiters = 500)
+    sol = solve(
+        prob, ParallelPSOKernel(n_particles; backend);
+        maxiters = 500, c1 = 1.4f0, c2 = 1.6f0
+    )
 
     @test prob.f(prob.u0, prob.p) > sol.objective
 
@@ -38,7 +41,9 @@ include("./utils.jl")
     sol = solve(
         prob,
         ParallelPSOKernel(n_particles; backend, global_update = false),
-        maxiters = 1000
+        maxiters = 1000,
+        c1 = 1.4f0,
+        c2 = 1.6f0
     )
 
     @test prob.f(prob.u0, prob.p) > sol.objective
@@ -48,7 +53,9 @@ include("./utils.jl")
     sol = solve(
         prob,
         ParallelSyncPSOKernel(n_particles; backend),
-        maxiters = 500
+        maxiters = 500,
+        c1 = 1.4f0,
+        c2 = 1.6f0
     )
 
     @test prob.f(prob.u0, prob.p) > sol.objective

--- a/test/lbfgs.jl
+++ b/test/lbfgs.jl
@@ -54,7 +54,11 @@ l0 = rosenbrock(x0, p)
 @time sol = Optimization.solve(
     prob,
     ParallelParticleSwarms.HybridPSO(; backend),
-    maxiters = 30
+    maxiters = 30,
+    w = 0.7f0,
+    wdamp = 0.99f0,
+    c1 = 1.4f0,
+    c2 = 1.6f0
 )
 @show sol.objective
 

--- a/test/regression.jl
+++ b/test/regression.jl
@@ -45,7 +45,9 @@ using QuasiMonteCarlo
     sol = solve(
         prob,
         SerialPSO(n_particles),
-        maxiters = 600
+        maxiters = 600,
+        c1 = 1.4f0,
+        c2 = 1.6f0
     )
 
     @test sol.objective < 1.0e-4


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
