### PR TITLE
Bump ParallelParticleSwarms to v1.1.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParallelParticleSwarms"
 uuid = "ab63da0c-63b4-40fa-a3b7-d2cba5be6419"
 authors = ["Utkarsh <rajpututkarsh530@gmail.com> and contributors"]
-version = "1.1.3"
+version = "1.1.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Bumps `ParallelParticleSwarms` **v1.1.3 → v1.1.4** (patch) so the accumulated unreleased `src/` changes on `main` can be registered.

**Rationale:** Merge pull request #112 from ChrisRackauckas-Claude/agent/rendered-public-docs-qa (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)